### PR TITLE
include "QPainterPath" in JMPX/vol/volumemeter.cpp

### DIFF
--- a/JMPX/vol/volumemeter.cpp
+++ b/JMPX/vol/volumemeter.cpp
@@ -1,5 +1,5 @@
 #include "volumemeter.h"
-
+#include <QPainterPath>
 #include <iostream>
 Volumemeter::Volumemeter(QWidget *parent) :
     QWidget(parent)


### PR DESCRIPTION
Hi. Please forgive my poor English.

I wanted to try out the latest version, so I cloned a Git repository and built it, but I got a ```error: aggregate 'QPainterPath path' has incomplete type and cannot be defined``` error at the "make" and the build process stopped.

I found out that the cause was ```JMPX/vol/volumemeter.cpp```, so I corrected it.
After correction, I could build and launch on Univalent GNU/Linux (an Arch-based distro) and Windows 10 successfully.